### PR TITLE
Update 2-tipos-de-dados.md

### DIFF
--- a/docs/3-Basico da Linguagem/2-tipos-de-dados.md
+++ b/docs/3-Basico da Linguagem/2-tipos-de-dados.md
@@ -297,7 +297,7 @@ r.to_s
 
 ```ruby
 r = "Ruby"
-r.to_a
+r.split("")
 => ["R", "u", "b", "y"]
 ```
 


### PR DESCRIPTION
Houve uma atualização na qual converter a palavra para array utilizando to_a não estava funcionando e por isso coloquei com r.split("")